### PR TITLE
Provide support for DateTimes in DateRange

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     },
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.4",
         "ext-bcmath": "*",
         "ext-intl": "*",
         "ext-mbstring": "*"

--- a/library/Vo/DateRange.php
+++ b/library/Vo/DateRange.php
@@ -26,7 +26,7 @@ class DateRange
      *
      * @var string
      */
-    const FUTURE = '9999-01-01';
+    const FUTURE = '9999-12-31';
 
     /**
      * Far-past ISO-8601 date

--- a/library/Vo/DateTimeRange.php
+++ b/library/Vo/DateTimeRange.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * PHP Value Objects
+ *
+ * @author    Gordon Stratton <gordon.stratton@gmail.com>
+ * @copyright 2011-2014 Gordon Stratton
+ * @license   http://opensource.org/licenses/BSD-2-Clause BSD 2-Clause
+ * @link      https://github.com/gws/php-valueobjects
+ */
+
+namespace Vo;
+
+use OutOfRangeException;
+
+/**
+ * Class to deal with and perform operations on ranges of dates.
+ *
+ * @link http://www.martinfowler.com/eeaDev/Range.html
+ */
+class DateTimeRange extends DateRange
+{
+    /**
+     * Far-future ISO-8601 date
+     *
+     * @var string
+     */
+    const FUTURE = '9999-12-31 23:59:59';
+
+    /**
+     * Far-past ISO-8601 date
+     *
+     * @var string
+     */
+    const PAST = '1000-01-01 00:00:00';
+
+    /**
+     * Take the difference of two date ranges
+     *
+     * The difference of two date ranges in this case means that the overlap of
+     * the two ranges will be removed from the first range, and the result will
+     * be returned.
+     *
+     * This method will refuse to bisect the current date range (thus,
+     * confusingly, creating two date ranges), so the argument date range must
+     * begin prior to and end during the current date range, or begin during and
+     * end after the current date range.
+     *
+     * @param  DateRange           $arg Other DateRange to test
+     * @return DateRange
+     * @throws OutOfRangeException
+     */
+    public function diff(DateRange $arg)
+    {
+        if (!$this->overlaps($arg)) {
+            throw new OutOfRangeException('Argument must overlap this range');
+        }
+
+        if ($this->getStart() < $arg->getStart()
+            && $this->getEnd() > $arg->getEnd()
+        ) {
+            throw new OutOfRangeException('Argument must not be exclusively contained within this range');
+        }
+
+        if ($this->getStart() < $arg->getStart()) {
+            return new static(
+                clone $this->getStart(),
+                date_modify(clone $arg->getStart(), '-1 second')
+            );
+        }
+
+        return new static(
+            date_modify(clone $arg->getEnd(), '+1 second'),
+            clone $this->getEnd()
+        );
+    }
+
+    /**
+     * Convert the DateRange to an ISO-8601 interval string
+     *
+     * http://en.wikipedia.org/wiki/ISO_8601#Time_intervals
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        if ($this->isEmpty()) {
+            return '';
+        }
+
+        return implode(
+            '/',
+            array(
+                $this->getStart()->format('Y-m-d\TH:i:s\Z'),
+                $this->getEnd()->format('Y-m-d\TH:i:s\Z')
+            )
+        );
+    }
+}

--- a/library/Vo/DateTimeRange.php
+++ b/library/Vo/DateTimeRange.php
@@ -34,19 +34,20 @@ class DateTimeRange extends DateRange
     const PAST = '1000-01-01 00:00:00';
 
     /**
-     * Take the difference of two date ranges
+     * Take the difference of two datetime ranges
      *
-     * The difference of two date ranges in this case means that the overlap of
+     * The difference of two datetime ranges in this case means that the overlap of
      * the two ranges will be removed from the first range, and the result will
      * be returned.
      *
-     * This method will refuse to bisect the current date range (thus,
-     * confusingly, creating two date ranges), so the argument date range must
-     * begin prior to and end during the current date range, or begin during and
-     * end after the current date range.
+     * This method will refuse to bisect the current datetime range (thus,
+     * confusingly, creating two datetime ranges), so the argument datetime range must
+     * begin prior to and end during the current datetime range, or begin during and
+     * end after the current datetime range.
      *
-     * @param  DateRange           $arg Other DateRange to test
-     * @return DateRange
+     * @param DateRange|DateTimeRange $arg Other DateRange or DateTimeRange to test
+     *
+     * @return DateTimeRange
      * @throws OutOfRangeException
      */
     public function diff(DateRange $arg)

--- a/library/Vo/DateTimeRange.php
+++ b/library/Vo/DateTimeRange.php
@@ -90,8 +90,8 @@ class DateTimeRange extends DateRange
         return implode(
             '/',
             array(
-                $this->getStart()->format('Y-m-d\TH:i:s\Z'),
-                $this->getEnd()->format('Y-m-d\TH:i:s\Z')
+                $this->getStart()->format('c'),
+                $this->getEnd()->format('c')
             )
         );
     }

--- a/tests/VoTest/DateTimeRangeTest.php
+++ b/tests/VoTest/DateTimeRangeTest.php
@@ -1,0 +1,386 @@
+<?php
+
+namespace VoTest;
+
+use DateTime;
+use Vo\DateTimeRange;
+
+class DateTimeRangeTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFromIso8601()
+    {
+        $dr = DateTimeRange::fromIso8601('2009-06-07T09:06:07Z/2011-05-04T11:05:04Z');
+
+        $this->assertEquals(
+            new DateTime('2009-06-07T09:06:07Z'),
+            $dr->getStart()
+        );
+
+        $this->assertEquals(
+            new DateTime('2011-05-04T11:05:04Z'),
+            $dr->getEnd()
+        );
+
+        $this->setExpectedException('InvalidArgumentException');
+
+        $dr = DateTimeRange::fromIso8601('2009-06-07T09:06:07Z');
+    }
+
+    public function testFromData()
+    {
+        $dr1 = DateTimeRange::fromData(
+            (object)array(
+                'start' => '2010-09-06T10:09:06Z',
+                'end' => '2011-06-07T11:06:07Z'
+            )
+        );
+
+        $dr2 = DateTimeRange::fromData(
+            array(
+                'start' => '2010-09-06T10:09:06Z',
+                'end' => '2011-06-07T11:06:07Z'
+            )
+        );
+
+        foreach (array($dr1, $dr2) as $dr) {
+            $this->assertEquals(
+                new DateTime('2010-09-06T10:09:06Z'),
+                $dr->getStart()
+            );
+
+            $this->assertEquals(
+                new DateTime('2011-06-07T11:06:07Z'),
+                $dr->getEnd()
+            );
+        }
+
+        $dr3 = DateTimeRange::fromData(
+            array(
+                'start' => '2010-09-07T10:09:07Z'
+            )
+        );
+
+        $this->assertEquals(
+            new DateTime('2010-09-07T10:09:07Z'),
+            $dr3->getStart()
+        );
+
+        $this->assertEquals(
+            new DateTime(DateTimeRange::FUTURE),
+            $dr3->getEnd()
+        );
+
+        $dr4 = DateTimeRange::fromData(
+            array(
+                'end' => '2011-06-08T11:06:08Z'
+            )
+        );
+
+        $this->assertEquals(
+            new DateTime(DateTimeRange::PAST),
+            $dr4->getStart()
+        );
+
+        $this->assertEquals(
+            new DateTime('2011-06-08T11:06:08Z'),
+            $dr4->getEnd()
+        );
+    }
+
+    public function testEquals()
+    {
+        $eq1 = new DateTimeRange(
+            new DateTime('2010-01-02T10:01:02Z'),
+            new DateTime('2010-01-03T10:01:03Z')
+        );
+
+        $eq2 = new DateTimeRange(
+            new DateTime('2010-01-02T10:01:02Z'),
+            new DateTime('2010-01-03T10:01:03Z')
+        );
+
+        $this->assertTrue($eq1->equals($eq2));
+        $this->assertTrue($eq2->equals($eq1));
+
+        $ne1 = new DateTimeRange(
+            new DateTime('2010-02-01T10:02:01Z'),
+            new DateTime('2010-01-03T10:01:03Z')
+        );
+
+        $ne2 = new DateTimeRange(
+            new DateTime('2010-01-31T10:01:31Z'),
+            new DateTime('2010-01-03T10:01:03Z')
+        );
+
+        $this->assertFalse($ne1->equals($ne2));
+        $this->assertFalse($ne2->equals($ne1));
+    }
+
+    public function testIncludes()
+    {
+        $dr = new DateTimeRange(
+            new DateTime('2006-07-08T06:07:08Z'),
+            new DateTime('2006-09-05T06:09:05Z')
+        );
+
+        $this->assertTrue($dr->includes(new DateTime('2006-07-08T06:07:08Z')));
+        $this->assertTrue($dr->includes(new DateTime('2006-08-01T06:08:01Z')));
+        $this->assertFalse($dr->includes(new DateTime('2006-07-07T06:07:07Z')));
+
+        $this->assertTrue($dr->includes(new DateTimeRange(
+            new DateTime('2006-07-08T06:07:08Z'),
+            new DateTime('2006-07-10T06:07:10Z')
+        )));
+        $this->assertTrue($dr->includes(new DateTimeRange(
+            new DateTime('2006-07-09T06:07:09Z'),
+            new DateTime('2006-09-05T06:09:05Z')
+        )));
+        $this->assertFalse($dr->includes(new DateTimeRange(
+            new DateTime('2006-07-07T06:07:07Z'),
+            new DateTime('2006-07-08T06:07:08Z')
+        )));
+        $this->assertFalse($dr->includes(new DateTimeRange(
+            new DateTime('2006-07-09T06:07:09Z'),
+            new DateTime('2006-09-06T06:09:06Z')
+        )));
+    }
+
+    public function testOverlaps()
+    {
+        $dr = new DateTimeRange(
+            new DateTime('2006-07-08T06:07:08Z'),
+            new DateTime('2006-09-05T06:09:05Z')
+        );
+
+        $this->assertTrue($dr->overlaps(new DateTimeRange(
+            new DateTime('2006-07-08T06:07:08Z'),
+            new DateTime('2006-07-10T06:07:10Z')
+        )));
+        $this->assertTrue($dr->overlaps(new DateTimeRange(
+            new DateTime('2006-07-09T06:07:09Z'),
+            new DateTime('2006-09-05T06:09:05Z')
+        )));
+        $this->assertTrue($dr->overlaps(new DateTimeRange(
+            new DateTime('2006-07-07T06:07:07Z'),
+            new DateTime('2006-07-08T06:07:08Z')
+        )));
+        $this->assertTrue($dr->overlaps(new DateTimeRange(
+            new DateTime('2006-07-09T06:07:09Z'),
+            new DateTime('2006-09-06T06:09:06Z')
+        )));
+        $this->assertFalse($dr->overlaps(new DateTimeRange(
+            new DateTime('2006-07-06T06:07:06Z'),
+            new DateTime('2006-07-07T06:07:07Z')
+        )));
+    }
+
+    public function testGap()
+    {
+        $dr1 = new DateTimeRange(
+            new DateTime('2006-07-08T06:07:08Z'),
+            new DateTime('2006-09-05T06:09:05Z')
+        );
+
+        $dr2 = new DateTimeRange(
+            new DateTime('2006-09-09T06:09:09Z'),
+            new DateTime('2006-09-15T06:09:15Z')
+        );
+
+        $this->assertEquals(
+            3,
+            $dr2->gap($dr1)
+        );
+
+        $this->assertEquals(
+            3,
+            $dr1->gap($dr2)
+        );
+
+        $dr3 = new DateTimeRange(
+            new DateTime('2006-09-04T06:09:04Z'),
+            new DateTime('2006-09-15T06:09:15Z')
+        );
+
+        $this->assertFalse($dr1->gap($dr3));
+        $this->assertFalse($dr3->gap($dr1));
+    }
+
+    public function testAbuts()
+    {
+        $dr1 = new DateTimeRange(
+            new DateTime('2006-07-08T06:07:08Z'),
+            new DateTime('2006-09-05T06:09:05Z')
+        );
+
+        $dr2 = new DateTimeRange(
+            new DateTime('2006-09-06T06:09:06Z'),
+            new DateTime('2006-09-15T06:09:15Z')
+        );
+
+        $this->assertTrue($dr2->abuts($dr1));
+        $this->assertTrue($dr1->abuts($dr2));
+
+        $dr3 = new DateTimeRange(
+            new DateTime('2006-09-07T06:09:07Z'),
+            new DateTime('2006-09-15T06:09:15Z')
+        );
+
+        $this->assertFalse($dr1->abuts($dr3));
+        $this->assertFalse($dr3->abuts($dr1));
+    }
+
+    public function testDiff()
+    {
+        $dr1 = new DateTimeRange(
+            new DateTime('2006-07-01T06:07:01Z'),
+            new DateTime('2006-08-01T06:08:01Z')
+        );
+
+        $dr2 = new DateTimeRange(
+            new DateTime('2006-07-15T06:07:15Z'),
+            new DateTime('2006-08-15T06:08:15Z')
+        );
+
+        $dr3 = new DateTimeRange(
+            new DateTime('2006-07-02T06:07:02Z'),
+            new DateTime('2006-07-13T06:07:13Z')
+        );
+
+        $this->assertEquals(
+            new DateTimeRange(
+                new DateTime('2006-07-01T06:07:01Z'),
+                new DateTime('2006-07-15T06:07:14Z')
+            ),
+            $dr1->diff($dr2)
+        );
+
+        $this->assertEquals(
+            new DateTimeRange(
+                new DateTime('2006-08-01T06:08:02Z'),
+                new DateTime('2006-08-15T06:08:15Z')
+            ),
+            $dr2->diff($dr1)
+        );
+
+        $this->setExpectedException('OutOfRangeException');
+
+        $dr1->diff($dr3);
+    }
+
+    public function testIsContiguous()
+    {
+        $dr1 = new DateTimeRange(
+            new DateTime('2006-07-08T06:07:08Z'),
+            new DateTime('2006-09-05T06:09:05Z')
+        );
+
+        $dr2 = new DateTimeRange(
+            new DateTime('2006-09-06T06:09:06Z'),
+            new DateTime('2006-09-15T06:09:15Z')
+        );
+
+        $dr3 = new DateTimeRange(
+            new DateTime('2006-09-15T06:09:15Z'),
+            new DateTime('2006-09-25T06:09:25Z')
+        );
+
+        $this->assertFalse(DateTimeRange::isContiguous(array($dr1, $dr2, $dr3)));
+
+        $dr4 = new DateTimeRange(
+            new DateTime('2006-09-16T06:09:16Z'),
+            new DateTime('2006-09-25T06:09:25Z')
+        );
+
+        $this->assertTrue(DateTimeRange::isContiguous(array($dr1, $dr2, $dr4)));
+        $this->assertTrue(DateTimeRange::isContiguous(array($dr4, $dr1, $dr2)));
+    }
+
+    public function testSeriesStart()
+    {
+        $dr1 = new DateTimeRange(
+            new DateTime('2006-07-08T06:07:08Z'),
+            new DateTime('2006-09-05T06:09:05Z')
+        );
+
+        $dr2 = new DateTimeRange(
+            new DateTime('2006-09-06T06:09:06Z'),
+            new DateTime('2006-09-15T06:09:15Z')
+        );
+
+        $dr3 = new DateTimeRange(
+            new DateTime('2006-09-15T06:09:15Z'),
+            new DateTime('2006-09-25T06:09:25Z')
+        );
+
+        $this->assertEquals(
+            new DateTime('2006-07-08T06:07:08Z'),
+            DateTimeRange::getSeriesStart(array($dr1, $dr2, $dr3))
+        );
+    }
+
+    public function testSeriesEnd()
+    {
+        $dr1 = new DateTimeRange(
+            new DateTime('2006-07-08T06:07:08Z'),
+            new DateTime('2006-09-05T06:09:05Z')
+        );
+
+        $dr2 = new DateTimeRange(
+            new DateTime('2006-09-06T06:09:06Z'),
+            new DateTime('2006-09-15T06:09:15Z')
+        );
+
+        $dr3 = new DateTimeRange(
+            new DateTime('2006-09-15T06:09:15Z'),
+            new DateTime('2006-09-25T06:09:25Z')
+        );
+
+        $this->assertEquals(
+            new DateTime('2006-09-25T06:09:25Z'),
+            DateTimeRange::getSeriesEnd(array($dr1, $dr2, $dr3))
+        );
+    }
+
+    public function testCompareTo()
+    {
+        $dr1 = new DateTimeRange(
+            new DateTime('2006-07-08T06:07:08Z'),
+            new DateTime('2006-09-05T06:09:05Z')
+        );
+
+        $dr2 = new DateTimeRange(
+            new DateTime('2006-09-06T06:09:06Z'),
+            new DateTime('2006-09-15T06:09:15Z')
+        );
+
+        $this->assertEquals(
+            -1,
+            $dr1->compareTo($dr2)
+        );
+
+        $this->assertEquals(
+            1,
+            $dr2->compareTo($dr1)
+        );
+
+        $dr2 = clone($dr1);
+
+        $this->assertEquals(
+            0,
+            $dr1->compareTo($dr2)
+        );
+    }
+
+    public function testToString()
+    {
+        $dr1 = new DateTimeRange(
+            new DateTime('2006-09-06T06:09:06Z'),
+            new DateTime('2006-09-15T06:09:15Z')
+        );
+
+        $this->assertEquals(
+            '2006-09-06T06:09:06Z/2006-09-15T06:09:15Z',
+            $dr1->__toString()
+        );
+    }
+}

--- a/tests/VoTest/DateTimeRangeTest.php
+++ b/tests/VoTest/DateTimeRangeTest.php
@@ -379,7 +379,7 @@ class DateTimeRangeTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertEquals(
-            '2006-09-06T06:09:06Z/2006-09-15T06:09:15Z',
+            '2006-09-06T06:09:06+00:00/2006-09-15T06:09:15+00:00',
             $dr1->__toString()
         );
     }

--- a/tests/VoTest/DateTimeRangeTest.php
+++ b/tests/VoTest/DateTimeRangeTest.php
@@ -3,6 +3,7 @@
 namespace VoTest;
 
 use DateTime;
+use Vo\DateRange;
 use Vo\DateTimeRange;
 
 class DateTimeRangeTest extends \PHPUnit_Framework_TestCase
@@ -382,5 +383,21 @@ class DateTimeRangeTest extends \PHPUnit_Framework_TestCase
             '2006-09-06T06:09:06+00:00/2006-09-15T06:09:15+00:00',
             $dr1->__toString()
         );
+    }
+
+    public function testDiffWithDateRange()
+    {
+        $dr1 = new DateTimeRange(
+            new DateTime('2006-07-01T06:07:01Z'),
+            new DateTime('2006-08-01T06:08:01Z')
+        );
+
+        $dr2 = new DateRange(
+            new DateTime('2006-07-15'),
+            new DateTime('2006-08-15')
+        );
+
+        $this->assertEquals('2006-07-01T06:07:01+00:00/2006-07-14T23:59:59+01:00', $dr1->diff($dr2)->__toString());
+        $this->assertEquals('2006-08-02/2006-08-15', $dr2->diff($dr1)->__toString());
     }
 }

--- a/tests/VoTest/DateTimeRangeTest.php
+++ b/tests/VoTest/DateTimeRangeTest.php
@@ -3,6 +3,7 @@
 namespace VoTest;
 
 use DateTime;
+use DateTimeZone;
 use Vo\DateRange;
 use Vo\DateTimeRange;
 
@@ -393,8 +394,8 @@ class DateTimeRangeTest extends \PHPUnit_Framework_TestCase
         );
 
         $dr2 = new DateRange(
-            new DateTime('2006-07-15'),
-            new DateTime('2006-08-15')
+            new DateTime('2006-07-15', new DateTimeZone('Europe/London')),
+            new DateTime('2006-08-15', new DateTimeZone('Europe/London'))
         );
 
         $this->assertEquals('2006-07-01T06:07:01+00:00/2006-07-14T23:59:59+01:00', $dr1->diff($dr2)->__toString());


### PR DESCRIPTION
Currently `DateRange` only deals with dates. `diff()` amends date by a day and `__toString()` outputs only the date.

`DateTimeRange` overrides these 2 methods and processes times.

All unit tests cloned from `DateRangeTest`, times added and all pass.
