### PR TITLE
Relax type hints to DateTimeInterface and make use of DateTimeImmutable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: php
 
 php:
-  - "5.4"
-  - "5.5"
   - "5.6"
   - "7.0"
+  - "7.1"
 
 before_script:
   - composer install --dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - "5.6"
   - "7.0"
   - "7.1"
 
@@ -9,6 +8,7 @@ before_script:
   - composer install --dev
 
 script:
+  - ./vendor/bin/phpstan analyze --level 3 library
   - ./vendor/bin/phpunit -c ./tests/phpunit.xml.dist
   - ./vendor/bin/phpcs --standard=PSR2 library
   - ./vendor/bin/phpcs --standard=PSR2 tests/VoTest

--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,10 @@
         }
     },
     "require": {
-        "php": ">=5.4"
+        "php": ">=5.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0",
+        "phpunit/phpunit": "~5.7",
         "squizlabs/php_codesniffer": "~2.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,11 @@
         }
     },
     "require": {
-        "php": ">=5.6"
+        "php": "~7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.7",
+        "phpunit/phpunit": "~6.0",
+        "phpstan/phpstan": "~0.6.0",
         "squizlabs/php_codesniffer": "~2.0"
     },
     "suggest": {

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
-FROM php:7.0-cli
+FROM php:7.1-cli
 
-RUN \
-  apt-get update \
-  && apt-get install -y libicu-dev \
-  && docker-php-ext-install -j$(nproc) bcmath intl mbstring
+RUN apt-get update \
+    && apt-get install -y libicu-dev \
+    && docker-php-ext-install -j$(nproc) bcmath intl \
+    && rm -rf /var/lib/apt/lists/*

--- a/library/Vo/DateTimeRange.php
+++ b/library/Vo/DateTimeRange.php
@@ -64,14 +64,14 @@ class DateTimeRange extends DateRange
 
         if ($this->getStart() < $arg->getStart()) {
             return new static(
-                clone $this->getStart(),
-                date_modify(clone $arg->getStart(), '-1 second')
+                $this->getStart(),
+                $arg->getStart()->modify('-1 second')
             );
         }
 
         return new static(
-            date_modify(clone $arg->getEnd(), '+1 second'),
-            clone $this->getEnd()
+            $arg->getEnd()->modify('+1 second'),
+            $this->getEnd()
         );
     }
 

--- a/library/Vo/Money.php
+++ b/library/Vo/Money.php
@@ -324,8 +324,7 @@ class Money
         if (is_numeric($money)) {
             $money = new Money(
                 $money,
-                $this->getCurrency(),
-                $this->getScale()
+                $this->getCurrency()
             );
         } else {
             if (!$money instanceof Money) {
@@ -361,8 +360,7 @@ class Money
                 $other->getAmount(),
                 $this->getScale()
             ),
-            $this->getCurrency(),
-            $this->getScale()
+            $this->getCurrency()
         );
     }
 }

--- a/tests/VoTest/DateRangeTest.php
+++ b/tests/VoTest/DateRangeTest.php
@@ -3,6 +3,7 @@
 namespace VoTest;
 
 use DateTime;
+use DateTimeImmutable;
 use Vo\DateRange;
 
 class DateRangeTest extends \PHPUnit_Framework_TestCase
@@ -17,7 +18,7 @@ class DateRangeTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertEquals(
-            new DateTime('2011-05-04'),
+            new DateTimeImmutable('2011-05-04'),
             $dr->getEnd()
         );
 
@@ -49,7 +50,7 @@ class DateRangeTest extends \PHPUnit_Framework_TestCase
             );
 
             $this->assertEquals(
-                new DateTime('2011-06-07'),
+                new DateTimeImmutable('2011-06-07'),
                 $dr->getEnd()
             );
         }
@@ -66,7 +67,7 @@ class DateRangeTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertEquals(
-            new DateTime(DateRange::FUTURE),
+            new DateTimeImmutable(DateRange::FUTURE),
             $dr3->getEnd()
         );
 
@@ -82,7 +83,7 @@ class DateRangeTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertEquals(
-            new DateTime('2011-06-08'),
+            new DateTimeImmutable('2011-06-08'),
             $dr4->getEnd()
         );
     }
@@ -91,11 +92,11 @@ class DateRangeTest extends \PHPUnit_Framework_TestCase
     {
         $eq1 = new DateRange(
             new DateTime('2010-01-02'),
-            new DateTime('2010-01-03')
+            new DateTimeImmutable('2010-01-03')
         );
 
         $eq2 = new DateRange(
-            new DateTime('2010-01-02'),
+            new DateTimeImmutable('2010-01-02'),
             new DateTime('2010-01-03')
         );
 
@@ -103,8 +104,8 @@ class DateRangeTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($eq2->equals($eq1));
 
         $ne1 = new DateRange(
-            new DateTime('2010-02-01'),
-            new DateTime('2010-01-03')
+            new DateTimeImmutable('2010-02-01'),
+            new DateTimeImmutable('2010-01-03')
         );
 
         $ne2 = new DateRange(
@@ -124,13 +125,44 @@ class DateRangeTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertTrue($dr->includes(new DateTime('2006-07-08')));
-        $this->assertTrue($dr->includes(new DateTime('2006-08-01')));
+        $this->assertTrue($dr->includes(new DateTimeImmutable('2006-08-01')));
         $this->assertFalse($dr->includes(new DateTime('2006-07-07')));
 
-        $this->assertTrue($dr->includes(new DateRange(new DateTime('2006-07-08'), new DateTime('2006-07-10'))));
-        $this->assertTrue($dr->includes(new DateRange(new DateTime('2006-07-09'), new DateTime('2006-09-05'))));
-        $this->assertFalse($dr->includes(new DateRange(new DateTime('2006-07-07'), new DateTime('2006-07-08'))));
-        $this->assertFalse($dr->includes(new DateRange(new DateTime('2006-07-09'), new DateTime('2006-09-06'))));
+        $this->assertTrue(
+            $dr->includes(
+                new DateRange(
+                    new DateTime('2006-07-08'),
+                    new DateTime('2006-07-10')
+                )
+            )
+        );
+
+        $this->assertTrue(
+            $dr->includes(
+                new DateRange(
+                    new DateTimeImmutable('2006-07-09'),
+                    new DateTime('2006-09-05')
+                )
+            )
+        );
+
+        $this->assertFalse(
+            $dr->includes(
+                new DateRange(
+                    new DateTime('2006-07-07'),
+                    new DateTimeImmutable('2006-07-08')
+                )
+            )
+        );
+
+        $this->assertFalse(
+            $dr->includes(
+                new DateRange(
+                    new DateTimeImmutable('2006-07-09'),
+                    new DateTimeImmutable('2006-09-06')
+                )
+            )
+        );
     }
 
     public function testOverlaps()
@@ -140,11 +172,50 @@ class DateRangeTest extends \PHPUnit_Framework_TestCase
             new DateTime('2006-09-05')
         );
 
-        $this->assertTrue($dr->overlaps(new DateRange(new DateTime('2006-07-08'), new DateTime('2006-07-10'))));
-        $this->assertTrue($dr->overlaps(new DateRange(new DateTime('2006-07-09'), new DateTime('2006-09-05'))));
-        $this->assertTrue($dr->overlaps(new DateRange(new DateTime('2006-07-07'), new DateTime('2006-07-08'))));
-        $this->assertTrue($dr->overlaps(new DateRange(new DateTime('2006-07-09'), new DateTime('2006-09-06'))));
-        $this->assertFalse($dr->overlaps(new DateRange(new DateTime('2006-07-06'), new DateTime('2006-07-07'))));
+        $this->assertTrue(
+            $dr->overlaps(
+                new DateRange(
+                    new DateTime('2006-07-08'),
+                    new DateTime('2006-07-10')
+                )
+            )
+        );
+
+        $this->assertTrue(
+            $dr->overlaps(
+                new DateRange(
+                    new DateTime('2006-07-09'),
+                    new DateTimeImmutable('2006-09-05')
+                )
+            )
+        );
+
+        $this->assertTrue(
+            $dr->overlaps(
+                new DateRange(
+                    new DateTimeImmutable('2006-07-07'),
+                    new DateTime('2006-07-08')
+                )
+            )
+        );
+
+        $this->assertTrue(
+            $dr->overlaps(
+                new DateRange(
+                    new DateTimeImmutable('2006-07-09'),
+                    new DateTimeImmutable('2006-09-06')
+                )
+            )
+        );
+
+        $this->assertFalse(
+            $dr->overlaps(
+                new DateRange(
+                    new DateTimeImmutable('2006-07-06'),
+                    new DateTimeImmutable('2006-07-07')
+                )
+            )
+        );
     }
 
     public function testGap()

--- a/tests/VoTest/DateRangeTest.php
+++ b/tests/VoTest/DateRangeTest.php
@@ -4,9 +4,12 @@ namespace VoTest;
 
 use DateTime;
 use DateTimeImmutable;
+use InvalidArgumentException;
+use OutOfRangeException;
+use PHPUnit\Framework\TestCase;
 use Vo\DateRange;
 
-class DateRangeTest extends \PHPUnit_Framework_TestCase
+class DateRangeTest extends TestCase
 {
     public function testFromIso8601()
     {
@@ -22,7 +25,7 @@ class DateRangeTest extends \PHPUnit_Framework_TestCase
             $dr->getEnd()
         );
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
 
         $dr = DateRange::fromIso8601('2009-06-07');
     }
@@ -306,7 +309,7 @@ class DateRangeTest extends \PHPUnit_Framework_TestCase
             $dr2->diff($dr1)
         );
 
-        $this->setExpectedException('OutOfRangeException');
+        $this->expectException(OutOfRangeException::class);
 
         $dr1->diff($dr3);
     }

--- a/tests/VoTest/DateTimeRangeTest.php
+++ b/tests/VoTest/DateTimeRangeTest.php
@@ -4,10 +4,13 @@ namespace VoTest;
 
 use DateTime;
 use DateTimeZone;
+use InvalidArgumentException;
+use OutOfRangeException;
+use PHPUnit\Framework\TestCase;
 use Vo\DateRange;
 use Vo\DateTimeRange;
 
-class DateTimeRangeTest extends \PHPUnit_Framework_TestCase
+class DateTimeRangeTest extends TestCase
 {
     public function testFromIso8601()
     {
@@ -23,7 +26,7 @@ class DateTimeRangeTest extends \PHPUnit_Framework_TestCase
             $dr->getEnd()
         );
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
 
         $dr = DateTimeRange::fromIso8601('2009-06-07T09:06:07Z');
     }
@@ -264,7 +267,7 @@ class DateTimeRangeTest extends \PHPUnit_Framework_TestCase
             $dr2->diff($dr1)
         );
 
-        $this->setExpectedException('OutOfRangeException');
+        $this->expectException(OutOfRangeException::class);
 
         $dr1->diff($dr3);
     }

--- a/tests/VoTest/IpTest.php
+++ b/tests/VoTest/IpTest.php
@@ -3,24 +3,22 @@
 namespace VoTest;
 
 use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
 use Vo\Ip;
 
-class IpTest extends \PHPUnit_Framework_TestCase
+class IpTest extends TestCase
 {
     /**
      * @dataProvider rawIpProvider
      */
     public function testCreation($raw, $is_valid)
     {
-        try {
-            $mac = new Ip($raw);
-        } catch (InvalidArgumentException $e) {
-            if (!$is_valid) {
-                return;
-            }
-
-            throw $e;
+        if (!$is_valid) {
+            $this->expectException(InvalidArgumentException::class);
         }
+
+        $ip = new Ip($raw);
+        $this->assertInstanceOf(Ip::class, $ip);
     }
 
     public function testFormat()

--- a/tests/VoTest/MacTest.php
+++ b/tests/VoTest/MacTest.php
@@ -3,24 +3,22 @@
 namespace VoTest;
 
 use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
 use Vo\Mac;
 
-class MacTest extends \PHPUnit_Framework_TestCase
+class MacTest extends TestCase
 {
     /**
      * @dataProvider rawMacProvider
      */
     public function testCreation($raw, $is_valid)
     {
-        try {
-            $mac = new Mac($raw);
-        } catch (InvalidArgumentException $e) {
-            if (!$is_valid) {
-                return;
-            }
-
-            throw $e;
+        if (!$is_valid) {
+            $this->expectException(InvalidArgumentException::class);
         }
+
+        $mac = new Mac($raw);
+        $this->assertInstanceOf(Mac::class, $mac);
     }
 
     public function testFormatting()

--- a/tests/VoTest/MoneyTest.php
+++ b/tests/VoTest/MoneyTest.php
@@ -3,9 +3,10 @@
 namespace VoTest;
 
 use NumberFormatter;
+use PHPUnit\Framework\TestCase;
 use Vo\Money;
 
-class MoneyTest extends \PHPUnit_Framework_TestCase
+class MoneyTest extends TestCase
 {
     public function testAddTwoSmallNumbers()
     {


### PR DESCRIPTION
This change breaks backward compatibility, in that getStart() and getEnd() will always return instances of DateTimeImmutable instead of DateTime as they did previously.

PHP >=5.6 is now required. PHP 5.5 is EOL, and users who cannot upgrade should use older releases of this library.